### PR TITLE
Update the ember configure the locationType to has instead of auto.

### DIFF
--- a/ember-admin/config/environment.js
+++ b/ember-admin/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'ember-admin',
     environment: environment,
     rootURL: '/admin',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/ember-app/config/environment.js
+++ b/ember-app/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'ember-app',
     environment: environment,
     rootURL: '/app',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/ember-user/config/environment.js
+++ b/ember-user/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'ember-user',
     environment: environment,
     rootURL: '/user',
-    locationType: 'auto',
+    locationType: 'hash',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tiny-legend-web/src/main/webapp/userember-cli-live-reload.js
+++ b/tiny-legend-web/src/main/webapp/userember-cli-live-reload.js
@@ -1,0 +1,8 @@
+(function() {
+ var srcUrl = null;
+ var src = srcUrl || ((location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':49153/livereload.js');
+ var script    = document.createElement('script');
+ script.type   = 'text/javascript';
+ script.src    = src;
+ document.getElementsByTagName('head')[0].appendChild(script);
+}());


### PR DESCRIPTION
When in ‘auto’, the URL path would be something like ‘/user/login’.
When in ‘hash’, the URL path would be something like ‘/user/#/login’.

In first ‘auto’ model, server container will treat it as sub folder hence it would not have folder /login under /user so we will get 404 when doing refresh from page.
When doing hash, server container will look at ‘/user’, then use ‘#/login’ as mark in the page. In /user, we have index.html which is severed as default page. So we can find the page.